### PR TITLE
Filter out inherited variables from output files

### DIFF
--- a/.style-dictionary/config.js
+++ b/.style-dictionary/config.js
@@ -1,3 +1,5 @@
+const { inheritedVariablePrefix } = require( '../build/wikimedia-ui-base/config' );
+
 const StyleDictionary = require( 'style-dictionary' ).extend( {
 	include: ['node_modules/wikimedia-ui-base/tokens.json'],
 	source: ['properties/**/*.json'],
@@ -7,7 +9,8 @@ const StyleDictionary = require( 'style-dictionary' ).extend( {
 			buildPath: 'dist/tokens/',
 			files: [{
 				destination: '_variables.scss',
-				format: 'scss/variables'
+				format: 'scss/variables',
+				filter: 'removePrefixedVars'
 			}]
 		},
 		css: {
@@ -15,7 +18,8 @@ const StyleDictionary = require( 'style-dictionary' ).extend( {
 			buildPath: 'dist/tokens/',
 			files: [{
 				destination: 'variables.css',
-				format: 'css/variables'
+				format: 'css/variables',
+				filter: 'removePrefixedVars'
 			}]
 		},
 		less: {
@@ -23,7 +27,8 @@ const StyleDictionary = require( 'style-dictionary' ).extend( {
 			buildPath: 'dist/tokens/',
 			files: [{
 				destination: '_variables.less',
-				format: 'less/variables'
+				format: 'less/variables',
+				filter: 'removePrefixedVars'
 			}]
 		},
 		js: {
@@ -31,7 +36,8 @@ const StyleDictionary = require( 'style-dictionary' ).extend( {
 			buildPath: 'dist/tokens/',
 			files: [{
 				destination: 'index.js',
-				format: 'javascript/es6'
+				format: 'javascript/es6',
+				filter: 'removePrefixedVars'
 			}]
 		},
 		'less-dev': {
@@ -39,7 +45,8 @@ const StyleDictionary = require( 'style-dictionary' ).extend( {
 			buildPath: 'src/tokens/',
 			files: [{
 				destination: '_variables.less',
-				format: 'less/variables'
+				format: 'less/variables',
+				filter: 'removePrefixedVars'
 			}]
 		},
 		json: {
@@ -51,7 +58,8 @@ const StyleDictionary = require( 'style-dictionary' ).extend( {
 			buildPath: 'dist/tokens/',
 			files: [{
 				destination: 'index.json',
-				format: 'json'
+				format: 'json',
+				filter: 'removePrefixedVars'
 			}]
 		}
 	}
@@ -71,5 +79,10 @@ StyleDictionary.registerTransform( {
 		}
 	}
 } );
+
+StyleDictionary.registerFilter({
+	name: 'removePrefixedVars',
+	matcher: ( prop ) => !prop.name.startsWith( inheritedVariablePrefix )
+});
 
 StyleDictionary.buildAllPlatforms();

--- a/build/wikimedia-ui-base/config.js
+++ b/build/wikimedia-ui-base/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	inheritedVariablePrefix: 'wmf-',
+};

--- a/build/wikimedia-ui-base/index.js
+++ b/build/wikimedia-ui-base/index.js
@@ -2,13 +2,14 @@ const fs = require( 'fs' );
 const WIKIMEDIA_UI_BASE_DIR = `${__dirname}/../../node_modules/wikimedia-ui-base`;
 const lessToJson = require( 'less-to-json' );
 const lib = require( './lib' );
+const { inheritedVariablePrefix } = require( './config' );
 
 fs.writeFileSync(
 	`${WIKIMEDIA_UI_BASE_DIR}/tokens.json`,
 	JSON.stringify(
 		lib.structureForStyleDictionary(
 			lessToJson( `${WIKIMEDIA_UI_BASE_DIR}/wikimedia-ui-base.less` ),
-			'wmf-'
+			inheritedVariablePrefix
 		),
 		null,
 		'\t'


### PR DESCRIPTION
This adds a filter that prevents variables that we imported from the
wikimedia-ui-base.less file based on the prefix that we add from making
it into the build results that we don't want them in.